### PR TITLE
Codec middleware

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -51,22 +51,18 @@ func CodecFromList(codecs Codecs) Middleware {
 			var reqCodec, resCodec Codec
 			// get request codec
 			if reqCodec = codecs.Lookup(r.Header.Get(contentTypeHeader)); reqCodec == nil {
-				panic(
-					NewStatusError(
-						http.StatusBadRequest,
-						fmt.Sprintf("unsupported request codec: %q", r.Header.Get(contentTypeHeader)),
-					),
-				)
+				panic(NewStatusError(
+					http.StatusBadRequest,
+					fmt.Sprintf("unsupported request codec: %q", r.Header.Get(contentTypeHeader)),
+				))
 			}
 			r = r.WithContext(context.WithValue(r.Context(), codecKey{"req"}, reqCodec))
 			// get response codec
 			if resCodec = codecs.Lookup(r.Header.Get(acceptHeader)); resCodec == nil {
-				panic(
-					NewStatusError(
-						http.StatusBadRequest,
-						fmt.Sprintf("unsupported response codec: %q", r.Header.Get(acceptHeader)),
-					),
-				)
+				panic(NewStatusError(
+					http.StatusBadRequest,
+					fmt.Sprintf("unsupported response codec: %q", r.Header.Get(acceptHeader)),
+				))
 			}
 			r = r.WithContext(context.WithValue(r.Context(), codecKey{"res"}, resCodec))
 			// call the next handler

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,88 @@
+package mw
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	acceptHeader      = "Accept"
+)
+
+// codecKey is a private unique key that is used to put/get codec from the context.
+type codecKey struct{ kind string }
+
+// Encoder is responsible for data encoding.
+type Encoder interface {
+	Encode(v interface{}) error
+}
+
+// Decoder is responsible for data decoding.
+type Decoder interface {
+	Decode(v interface{}) error
+}
+
+// Codec can create Encoder(s) and Decoder(s) with provided io.Reader/io.Writer.
+type Codec interface {
+	// Ecoder instantiates the ecnoder part of the codec with provided writer.
+	Encoder(w io.Writer) Encoder
+	// Decoder instantiates the decoder part of the codec with provided reader.
+	Decoder(r io.Reader) Decoder
+	// MimeType returns the (main) mime type of the codec.
+	MimeType() string
+}
+
+// Codecs represents any kind of codec registry, thus it can be global registry
+// or a custom list of codecs that is supposed to be used for particular route.
+type Codecs interface {
+	// Lookup should find appropriate Codec by MimeType or return nil if not found.
+	Lookup(mimeType string) Codec
+}
+
+// CodecFromList middleware searches for suitable request/response codecs according to
+// "Content-Type" and "Accept" headers and puts the correct codecs into the context.
+// NOTE: do not use current function without PanicRecover middleware.
+func CodecFromList(codecs Codecs) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var reqCodec, resCodec Codec
+			// get request codec
+			if reqCodec = codecs.Lookup(r.Header.Get(contentTypeHeader)); reqCodec == nil {
+				panic(
+					NewStatusError(
+						http.StatusBadRequest,
+						fmt.Sprintf("unsupported request codec: %q", r.Header.Get(contentTypeHeader)),
+					),
+				)
+			}
+			r = r.WithContext(context.WithValue(r.Context(), codecKey{"req"}, reqCodec))
+			// get response codec
+			if resCodec = codecs.Lookup(r.Header.Get(acceptHeader)); resCodec == nil {
+				panic(
+					NewStatusError(
+						http.StatusBadRequest,
+						fmt.Sprintf("unsupported response codec: %q", r.Header.Get(acceptHeader)),
+					),
+				)
+			}
+			r = r.WithContext(context.WithValue(r.Context(), codecKey{"res"}, resCodec))
+			// call the next handler
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequestCodecFromContext pulls the Codec from a request context or or returns nil.
+func RequestCodecFromContext(ctx context.Context) Codec {
+	codec, _ := ctx.Value(codecKey{"req"}).(Codec)
+	return codec
+}
+
+// ResponseCodecFromContext pulls the Codec from a request context or returns nil.
+func ResponseCodecFromContext(ctx context.Context) Codec {
+	codec, _ := ctx.Value(codecKey{"res"}).(Codec)
+	return codec
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,118 @@
+package mw
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockCodecs []Codec
+
+func (cs mockCodecs) Lookup(mime string) Codec {
+	for _, codec := range cs {
+		if mime == codec.MimeType() {
+			return codec
+		}
+	}
+	return nil
+}
+
+type mockJSON struct{}
+
+func (j *mockJSON) Encoder(w io.Writer) Encoder { return json.NewEncoder(w) }
+
+func (j *mockJSON) Decoder(r io.Reader) Decoder { return json.NewDecoder(r) }
+
+func (j *mockJSON) MimeType() string { return "application/json" }
+
+type mockXML struct{}
+
+func (x *mockXML) Encoder(w io.Writer) Encoder { return xml.NewEncoder(w) }
+
+func (x *mockXML) Decoder(r io.Reader) Decoder { return xml.NewDecoder(r) }
+
+func (x *mockXML) MimeType() string { return "application/xml" }
+
+func TestCodecFromList(t *testing.T) {
+	type testCase struct {
+		title   string
+		handler http.Handler
+		request *http.Request
+		ctype   string
+		code    int
+		body    string
+	}
+
+	cases := []testCase{
+		{
+			title: "should throw an error if request codec in not supported",
+			handler: PanicRecover(PanicHandler)(
+				CodecFromList(mockCodecs{&mockJSON{}, &mockXML{}})(nil),
+			),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "", nil)
+				r.Header.Set(contentTypeHeader, "unknown")
+				return r
+			}(),
+			code: http.StatusBadRequest,
+			body: "unsupported request codec: \"unknown\"\n",
+		},
+		{
+			title: "should throw an error if response codec in not supported",
+			handler: PanicRecover(PanicHandler)(
+				CodecFromList(mockCodecs{&mockJSON{}, &mockXML{}})(nil),
+			),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "", nil)
+				r.Header.Set(contentTypeHeader, "application/json")
+				r.Header.Set(acceptHeader, "unknown")
+				return r
+			}(),
+			code: http.StatusBadRequest,
+			body: "unsupported response codec: \"unknown\"\n",
+		},
+		{
+			title: "should find corresponding codecs and handle the request successfully",
+			handler: PanicRecover(PanicHandler)(
+				CodecFromList(mockCodecs{&mockJSON{}, &mockXML{}})(
+					BodyClose(
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							type Data struct{ Test string }
+							var data Data
+							RequestCodecFromContext(r.Context()).Decoder(r.Body).Decode(&data)
+							ResponseCodecFromContext(r.Context()).Encoder(w).Encode(data)
+						}),
+					),
+				),
+			),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "", strings.NewReader("{\"test\":\"passed\"}\n"))
+				r.Header.Set(contentTypeHeader, "application/json")
+				r.Header.Set(acceptHeader, "application/xml")
+				return r
+			}(),
+			code: http.StatusOK,
+			body: "<Data><Test>passed</Test></Data>",
+		},
+	}
+
+	t.Run("Given middleware function", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.title, func(t *testing.T) {
+				w := httptest.NewRecorder()
+				tc.handler.ServeHTTP(w, tc.request)
+
+				if w.Code != tc.code {
+					t.Errorf("status code %d was expected to be %d", w.Code, tc.code)
+				}
+				if w.Body.String() != tc.body {
+					t.Errorf("response body %q was expected to be %q", w.Body.String(), tc.body)
+				}
+			})
+		}
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,7 @@
 package mw
 
+import "errors"
+
 // Error interface describes errors that contain HTTP status code.
 type Error interface {
 	error
@@ -13,16 +15,11 @@ type StatusError struct {
 }
 
 // NewStatusError is a constructor func for StatusError.
-func NewStatusError(code int, cause error) StatusError {
-	return StatusError{error: cause, code: code}
+func NewStatusError(code int, cause string) StatusError {
+	return StatusError{error: errors.New(cause), code: code}
 }
 
 // Code returns HTTP status code (to satisfy Error interface).
 func (e StatusError) Code() int {
 	return e.code
-}
-
-// Error returns the actual error message.
-func (e StatusError) Error() string {
-	return e.error.Error()
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,7 +1,6 @@
 package mw
 
 import (
-	"errors"
 	"net/http"
 	"testing"
 )
@@ -9,7 +8,7 @@ import (
 var _ Error = StatusError{}
 
 func TestStatusError(t *testing.T) {
-	err := NewStatusError(http.StatusNotFound, errors.New("not found"))
+	err := NewStatusError(http.StatusNotFound, "not found")
 	t.Run("test if StatusError returns expected error code", func(t *testing.T) {
 		if err.Code() != http.StatusNotFound {
 			t.Errorf("error code %d was expected to be %d", err.Code(), http.StatusNotFound)

--- a/panic_recover_test.go
+++ b/panic_recover_test.go
@@ -43,7 +43,7 @@ func Test_PanicRecover(t *testing.T) {
 			title: "catch an \"error with status code\" and report to the client",
 			nextHandler: http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
-					panic(NewStatusError(http.StatusBadRequest, errors.New("bad request")))
+					panic(NewStatusError(http.StatusBadRequest, "bad request"))
 				},
 			),
 			status: http.StatusBadRequest,


### PR DESCRIPTION
Includes:

- Interfaces: `Codec`, `Codecs`, `Decoder` and `Encoder`
- Middleware func `CodecFromList()` allows to retrieve request/response mime types from headers, find corresponding codecs from the provided codec list and put them into the request context
- `ResponseCodecFromContext()` - response codec extractor
- `RequestCodecFromContext()`- request codec extractor