### PR TITLE
Codec middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ $ go get github.com/tiny-go/middleware
 ### Currently available middleware
 - `BodyClose` - closes request body for each request
 - `ContextDeadline` - sets request timeout (demands additional logic in your app)
-- `PanicRecover` - catches the panics inside our chain
+- `PanicRecover` - catches the panics inside our chain, can be used as error handler (similar to `try/catch`) with corresponding panic handler
 - `SetHeaders` - provides an easy way to set response headers
 - `JwtHS256` - verifies JWT (JSON Web Token) signed with HMAC signing method and parses its body to the provided receiver that is going to be available to next handlers through the request context
+- `Codec` - searches for suitable request/response codecs according to "Content-Type" and "Accept" headers and puts  them into the context
 
 ### Experimental middleware
 It means that work is still in progress, a lot of things can be changed or even completely removed
@@ -41,6 +42,9 @@ It means that work is still in progress, a lot of things can be changed or even 
     	"os"
 
     	"github.com/tiny-go/middleware"
+    	"github.com/tiny-go/codec/driver"
+    	"github.com/tiny-go/codec/driver/json"
+    	"github.com/tiny-go/codec/driver/xml"
     )
 
     var (
@@ -56,6 +60,7 @@ It means that work is still in progress, a lot of things can be changed or even 
     			// with HTTP panic handler
     			New(mw.PanicRecover(mw.PanicHandler)).
     			Use(mw.BodyClose).
+    			Use(mw.Codec(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})).
     			Then(panicHandler),
     	)
     	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ go get github.com/tiny-go/middleware
 - `PanicRecover` - catches the panics inside our chain, can be used as error handler (similar to `try/catch`) with corresponding panic handler
 - `SetHeaders` - provides an easy way to set response headers
 - `JwtHS256` - verifies JWT (JSON Web Token) signed with HMAC signing method and parses its body to the provided receiver that is going to be available to next handlers through the request context
-- `Codec` - searches for suitable request/response codecs according to "Content-Type" and "Accept" headers and puts  them into the context
+- `Codec` - searches for suitable request/response codecs according to "Content-Type"/"Accept" headers and puts  them into the context
 
 ### Experimental middleware
 It means that work is still in progress, a lot of things can be changed or even completely removed

--- a/codec.go
+++ b/codec.go
@@ -23,10 +23,10 @@ type Codecs interface {
 	Lookup(mimeType string) codec.Codec
 }
 
-// CodecFromList middleware searches for suitable request/response codecs according to
+// Codec middleware searches for suitable request/response codecs according to
 // "Content-Type" and "Accept" headers and puts the correct codecs into the context.
 // NOTE: do not use current function without PanicRecover middleware.
-func CodecFromList(codecs Codecs) Middleware {
+func Codec(codecs Codecs) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var reqCodec, resCodec codec.Codec

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,65 @@
+package mw
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/tiny-go/codec"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	acceptHeader      = "Accept"
+)
+
+// codecKey is a private unique key that is used to put/get codec from the context.
+type codecKey struct{ kind string }
+
+// Codecs represents any kind of codec registry, thus it can be global registry
+// or a custom list of codecs that is supposed to be used for particular route.
+type Codecs interface {
+	// Lookup should find appropriate Codec by MimeType or return nil if not found.
+	Lookup(mimeType string) codec.Codec
+}
+
+// CodecFromList middleware searches for suitable request/response codecs according to
+// "Content-Type" and "Accept" headers and puts the correct codecs into the context.
+// NOTE: do not use current function without PanicRecover middleware.
+func CodecFromList(codecs Codecs) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var reqCodec, resCodec codec.Codec
+			// get request codec
+			if reqCodec = codecs.Lookup(r.Header.Get(contentTypeHeader)); reqCodec == nil {
+				panic(NewStatusError(
+					http.StatusBadRequest,
+					fmt.Errorf("unsupported request codec: %q", r.Header.Get(contentTypeHeader)),
+				))
+			}
+			r = r.WithContext(context.WithValue(r.Context(), codecKey{"req"}, reqCodec))
+			// get response codec
+			if resCodec = codecs.Lookup(r.Header.Get(acceptHeader)); resCodec == nil {
+				panic(NewStatusError(
+					http.StatusBadRequest,
+					fmt.Errorf("unsupported response codec: %q", r.Header.Get(acceptHeader)),
+				))
+			}
+			r = r.WithContext(context.WithValue(r.Context(), codecKey{"res"}, resCodec))
+			// call the next handler
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequestCodecFromContext pulls the Codec from a request context or or returns nil.
+func RequestCodecFromContext(ctx context.Context) codec.Codec {
+	codec, _ := ctx.Value(codecKey{"req"}).(codec.Codec)
+	return codec
+}
+
+// ResponseCodecFromContext pulls the Codec from a request context or returns nil.
+func ResponseCodecFromContext(ctx context.Context) codec.Codec {
+	codec, _ := ctx.Value(codecKey{"res"}).(codec.Codec)
+	return codec
+}

--- a/codec.go
+++ b/codec.go
@@ -24,7 +24,7 @@ type Codecs interface {
 }
 
 // Codec middleware searches for suitable request/response codecs according to
-// "Content-Type" and "Accept" headers and puts the correct codecs into the context.
+// "Content-Type"/"Accept" headers and puts the correct codecs into the context.
 // NOTE: do not use current function without PanicRecover middleware.
 func Codec(codecs Codecs) Middleware {
 	return func(next http.Handler) http.Handler {

--- a/codec_test.go
+++ b/codec_test.go
@@ -25,7 +25,7 @@ func TestCodecFromList(t *testing.T) {
 		{
 			title: "should throw an error if request codec in not supported",
 			handler: PanicRecover(PanicHandler)(
-				CodecFromList(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(nil),
+				Codec(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(nil),
 			),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(http.MethodGet, "", nil)
@@ -38,7 +38,7 @@ func TestCodecFromList(t *testing.T) {
 		{
 			title: "should throw an error if response codec in not supported",
 			handler: PanicRecover(PanicHandler)(
-				CodecFromList(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(nil),
+				Codec(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(nil),
 			),
 			request: func() *http.Request {
 				r, _ := http.NewRequest(http.MethodGet, "", nil)
@@ -52,7 +52,7 @@ func TestCodecFromList(t *testing.T) {
 		{
 			title: "should find corresponding codecs and handle the request successfully",
 			handler: PanicRecover(PanicHandler)(
-				CodecFromList(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(
+				Codec(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(
 					BodyClose(
 						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 							type Data struct{ Test string }

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,92 @@
+package mw
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tiny-go/codec/driver"
+	"github.com/tiny-go/codec/driver/json"
+	"github.com/tiny-go/codec/driver/xml"
+)
+
+func TestCodecFromList(t *testing.T) {
+	type testCase struct {
+		title   string
+		handler http.Handler
+		request *http.Request
+		ctype   string
+		code    int
+		body    string
+	}
+
+	cases := []testCase{
+		{
+			title: "should throw an error if request codec in not supported",
+			handler: PanicRecover(PanicHandler)(
+				CodecFromList(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(nil),
+			),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "", nil)
+				r.Header.Set(contentTypeHeader, "unknown")
+				return r
+			}(),
+			code: http.StatusBadRequest,
+			body: "unsupported request codec: \"unknown\"\n",
+		},
+		{
+			title: "should throw an error if response codec in not supported",
+			handler: PanicRecover(PanicHandler)(
+				CodecFromList(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(nil),
+			),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "", nil)
+				r.Header.Set(contentTypeHeader, "application/json")
+				r.Header.Set(acceptHeader, "unknown")
+				return r
+			}(),
+			code: http.StatusBadRequest,
+			body: "unsupported response codec: \"unknown\"\n",
+		},
+		{
+			title: "should find corresponding codecs and handle the request successfully",
+			handler: PanicRecover(PanicHandler)(
+				CodecFromList(driver.DummyRegistry{&json.JSON{}, &xml.XML{}})(
+					BodyClose(
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							type Data struct{ Test string }
+							var data Data
+							RequestCodecFromContext(r.Context()).Decoder(r.Body).Decode(&data)
+							ResponseCodecFromContext(r.Context()).Encoder(w).Encode(data)
+						}),
+					),
+				),
+			),
+			request: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "", strings.NewReader("{\"test\":\"passed\"}\n"))
+				r.Header.Set(contentTypeHeader, "application/json")
+				r.Header.Set(acceptHeader, "application/xml")
+				return r
+			}(),
+			code: http.StatusOK,
+			body: "<Data><Test>passed</Test></Data>",
+		},
+	}
+
+	t.Run("Given middleware function", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.title, func(t *testing.T) {
+				w := httptest.NewRecorder()
+				tc.handler.ServeHTTP(w, tc.request)
+
+				if w.Code != tc.code {
+					t.Errorf("status code %d was expected to be %d", w.Code, tc.code)
+				}
+				if w.Body.String() != tc.body {
+					t.Errorf("response body %q was expected to be %q", w.Body.String(), tc.body)
+				}
+			})
+		}
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -21,8 +21,3 @@ func NewStatusError(code int, cause error) StatusError {
 func (e StatusError) Code() int {
 	return e.code
 }
-
-// Error returns the actual error message.
-func (e StatusError) Error() string {
-	return e.error.Error()
-}


### PR DESCRIPTION
Includes:
- Middleware func `Codec()` allows to retrieve request/response mime types from headers, find corresponding codecs from the provided codec list and put them into the request context
- `ResponseCodecFromContext()` - response codec extractor
- `RequestCodecFromContext()`- request codec extractor